### PR TITLE
docs(examples): Add ReasoningContent field support in streaming examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,14 @@ for event := range events {
 
             // Process each choice in the response
             for _, choice := range streamResponse.Choices {
+                // Handle reasoning content (both reasoning and reasoning_content fields)
+                if choice.Delta.Reasoning != nil && *choice.Delta.Reasoning != "" {
+                    fmt.Printf("💭 Reasoning: %s\n", *choice.Delta.Reasoning)
+                }
+                if choice.Delta.ReasoningContent != nil && *choice.Delta.ReasoningContent != "" {
+                    fmt.Printf("💭 Reasoning: %s\n", *choice.Delta.ReasoningContent)
+                }
+                
                 if choice.Delta.Content != "" {
                     // Just print the content as it comes in
                     fmt.Print(choice.Delta.Content)

--- a/examples/reasoning/README.md
+++ b/examples/reasoning/README.md
@@ -1,0 +1,87 @@
+# DeepSeek Reasoner Example
+
+This example demonstrates how to properly display the reasoning process from DeepSeek Reasoner models using the SDK.
+
+## Features
+
+-   **Reasoning Display**: Shows the step-by-step thinking process of DeepSeek Reasoner
+-   **Streaming Support**: Displays reasoning content as it streams in real-time
+-   **Visual Formatting**: Clean, readable formatting with visual separators
+-   **Dual Field Support**: Handles both `reasoning` and `reasoning_content` fields
+
+## Key Differences from Basic Examples
+
+Unlike basic chat examples, this demonstrates:
+
+1. **Reasoning Detection**: Checks for both `choice.Delta.Reasoning` and `choice.Delta.ReasoningContent`
+2. **Visual Separation**: Clear visual distinction between reasoning and final response
+3. **Real-time Streaming**: Shows reasoning as it's generated, not just the final result
+4. **Enhanced Formatting**: Uses colors and borders to make reasoning more readable
+
+## Running the Example
+
+```bash
+# Set up environment variables
+export INFERENCE_GATEWAY_URL="http://localhost:8080/v1"
+export LLM_PROVIDER="deepseek"
+export LLM_MODEL="deepseek-reasoner"
+
+# Run the example
+go run main.go
+```
+
+## Expected Output
+
+```
+>DeepSeek Reasoner - Reasoning Display Example
+Provider: deepseek, Model: deepseek-reasoner
+
+S Question 1: What's the best way to learn a new programming language?
+
+> Assistant:
+
+= Reasoning Process:
+DeepSeek Reasoner Thinking
+This is a great question about learning methodologies. I should consider...
+1. Different learning styles (visual, hands-on, theoretical)
+2. Time constraints and available resources
+3. Prior programming experience level
+4. Specific goals (hobby, career, specific project)
+...
+
+=Final Response:
+The best approach to learning a new programming language depends on several factors...
+```
+
+## Code Explanation
+
+### Reasoning Detection
+
+```go
+hasReasoning := (choice.Delta.Reasoning != nil && *choice.Delta.Reasoning != "") ||
+    (choice.Delta.ReasoningContent != nil && *choice.Delta.ReasoningContent != "")
+```
+
+### Formatting
+
+-   **Reasoning**: Displayed in dim gray (`\033[90m`) with visual borders
+-   **Response**: Clear, normal formatting with section headers
+-   **Visual Separators**: Unicode box-drawing characters for clean presentation
+
+## Troubleshooting
+
+If you don't see reasoning content:
+
+1. **Check Model**: Ensure you're using `deepseek-reasoner`, not `deepseek-chat`
+2. **Verify Backend**: Confirm your inference gateway supports reasoning fields
+3. **Check Prompts**: Use questions that encourage step-by-step thinking
+4. **Debug Fields**: Add logging to see which fields contain reasoning data
+
+## Customization
+
+You can customize the reasoning display by:
+
+-   Modifying the visual formatting (colors, borders)
+-   Changing the questions to focus on specific topics
+-   Adding reasoning content to conversation history
+-   Implementing reasoning content filtering or highlighting

--- a/examples/reasoning/go.mod
+++ b/examples/reasoning/go.mod
@@ -1,0 +1,16 @@
+module reasoning-example
+
+go 1.24.5
+
+replace github.com/inference-gateway/sdk => ../..
+
+require github.com/inference-gateway/sdk v0.0.0-00010101000000-000000000000
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-resty/resty/v2 v2.16.3 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.10.0 // indirect
+	golang.org/x/net v0.33.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/examples/reasoning/go.sum
+++ b/examples/reasoning/go.sum
@@ -1,0 +1,16 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-resty/resty/v2 v2.16.3 h1:zacNT7lt4b8M/io2Ahj6yPypL7bqx9n1iprfQuodV+E=
+github.com/go-resty/resty/v2 v2.16.3/go.mod h1:hkJtXbA2iKHzJheXYvQ8snQES5ZLGKMwQ07xAwp/fiA=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
+golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
+golang.org/x/time v0.6.0 h1:eTDhh4ZXt5Qf0augr54TN6suAUudPcawVZeIAPU7D4U=
+golang.org/x/time v0.6.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/reasoning/main.go
+++ b/examples/reasoning/main.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	sdk "github.com/inference-gateway/sdk"
+)
+
+func main() {
+	// Environment setup - specifically configured for DeepSeek Reasoner
+	apiURL := os.Getenv("INFERENCE_GATEWAY_URL")
+	if apiURL == "" {
+		apiURL = "http://localhost:8080/v1"
+	}
+
+	// Default to DeepSeek Reasoner
+	providerName := os.Getenv("LLM_PROVIDER")
+	if providerName == "" {
+		providerName = "deepseek"
+	}
+
+	modelName := os.Getenv("LLM_MODEL")
+	if modelName == "" {
+		modelName = "deepseek-reasoner"
+	}
+
+	provider := sdk.Provider(providerName)
+	client := sdk.NewClient(&sdk.ClientOptions{BaseURL: apiURL})
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	// Conversation setup with prompts that encourage step-by-step reasoning
+	conversationHistory := []sdk.Message{
+		{
+			Role: sdk.System,
+			Content: `You are a helpful assistant. When answering questions, think through your response step by step. 
+Consider multiple approaches and explain your reasoning process clearly.`,
+		},
+	}
+
+	// Example questions that encourage reasoning
+	questions := []string{
+		"What's the best way to learn a new programming language? Consider different learning styles and time constraints.",
+		"Explain why quicksort has O(n log n) average time complexity. Walk me through the mathematical reasoning.",
+		"If I have a 1000-piece jigsaw puzzle and I can place 2 pieces per minute on average, but I slow down as the puzzle gets more complex, how should I estimate the total time needed?",
+		"Compare the trade-offs between microservices and monolithic architecture. What factors should influence this decision?",
+	}
+
+	fmt.Printf("🧠 DeepSeek Reasoner - Reasoning Display Example\n")
+	fmt.Printf("Provider: %s, Model: %s\n", provider, modelName)
+	fmt.Printf("═══════════════════════════════════════════════════════════════════════════════\n")
+
+	// Process each question
+	for i, question := range questions {
+		fmt.Printf("❓ Question %d: %s\n", i+1, question)
+
+		// Add user message to conversation
+		conversationHistory = append(conversationHistory, sdk.Message{
+			Role:    sdk.User,
+			Content: question,
+		})
+
+		// Generate response with streaming
+		eventCh, err := client.GenerateContentStream(ctx, provider, modelName, conversationHistory)
+		if err != nil {
+			log.Fatalf("Error initiating content stream: %v", err)
+		}
+
+		// Process stream with enhanced reasoning display
+		assistantMessage := sdk.Message{Role: sdk.Assistant}
+		var isThinking bool
+		var reasoningBuffer strings.Builder
+
+		fmt.Printf("🤖 Assistant: ")
+
+		for event := range eventCh {
+			if event.Event != nil && *event.Event == sdk.ContentDelta && event.Data != nil {
+				var streamResponse sdk.CreateChatCompletionStreamResponse
+				if err := json.Unmarshal(*event.Data, &streamResponse); err != nil {
+					continue
+				}
+
+				for _, choice := range streamResponse.Choices {
+					// Enhanced reasoning handling for DeepSeek Reasoner
+					hasReasoning := (choice.Delta.Reasoning != nil && *choice.Delta.Reasoning != "") ||
+						(choice.Delta.ReasoningContent != nil && *choice.Delta.ReasoningContent != "")
+
+					if hasReasoning {
+						if !isThinking {
+							isThinking = true
+							fmt.Printf("\n💭 Reasoning: ")
+						}
+
+						// Handle both reasoning and reasoning_content fields
+						var reasoningText string
+						if choice.Delta.Reasoning != nil && *choice.Delta.Reasoning != "" {
+							reasoningText = *choice.Delta.Reasoning
+						}
+						if choice.Delta.ReasoningContent != nil && *choice.Delta.ReasoningContent != "" {
+							reasoningText = *choice.Delta.ReasoningContent
+						}
+
+						// Display and buffer reasoning with nice formatting
+						if reasoningText != "" {
+							reasoningBuffer.WriteString(reasoningText)
+							// Display reasoning text directly as it streams
+							fmt.Printf("\033[90m%s\033[0m", reasoningText)
+						}
+					}
+
+					// Handle content (the final response)
+					if choice.Delta.Content != "" {
+						if isThinking {
+							isThinking = false
+							fmt.Printf("\n\n📝 Response: ")
+						}
+						fmt.Print(choice.Delta.Content)
+						assistantMessage.Content += choice.Delta.Content
+					}
+				}
+			}
+		}
+
+		// Add assistant response to conversation history
+		conversationHistory = append(conversationHistory, assistantMessage)
+
+		fmt.Print("\n" + strings.Repeat("═", 79) + "\n")
+
+		// Small delay between questions for readability
+		time.Sleep(1 * time.Second)
+	}
+
+	fmt.Printf("✅ DeepSeek Reasoner reasoning demonstration complete!\n")
+	fmt.Printf("💡 Key Features Demonstrated:\n")
+	fmt.Printf("   • Step-by-step reasoning display with visual formatting\n")
+	fmt.Printf("   • Proper handling of both 'reasoning' and 'reasoning_content' fields\n")
+	fmt.Printf("   • Clear separation between thinking process and final response\n")
+	fmt.Printf("   • Streaming reasoning content as it's generated\n")
+}

--- a/examples/reasoning/main.go
+++ b/examples/reasoning/main.go
@@ -12,6 +12,24 @@ import (
 	sdk "github.com/inference-gateway/sdk"
 )
 
+// isReasoningModel checks if the given model supports reasoning capabilities
+func isReasoningModel(provider sdk.Provider, model string) bool {
+	reasoningModels := map[sdk.Provider][]string{
+		sdk.Deepseek: {"deepseek-reasoner"},
+		// Add more providers and their reasoning models here as they become available
+		// Example: sdk.Openai: {"o1", "o1-preview", "o1-mini"},
+	}
+
+	if models, exists := reasoningModels[provider]; exists {
+		for _, reasoningModel := range models {
+			if model == reasoningModel {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func main() {
 	// Environment setup - specifically configured for DeepSeek Reasoner
 	apiURL := os.Getenv("INFERENCE_GATEWAY_URL")
@@ -34,6 +52,11 @@ func main() {
 	client := sdk.NewClient(&sdk.ClientOptions{BaseURL: apiURL})
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
+
+	// Validate that the selected model supports reasoning
+	if !isReasoningModel(provider, modelName) {
+		log.Fatalf("Error: Model '%s' from provider '%s' does not support reasoning capabilities. Please use a reasoning model like 'deepseek-reasoner'.", modelName, provider)
+	}
 
 	// Conversation setup with prompts that encourage step-by-step reasoning
 	conversationHistory := []sdk.Message{

--- a/examples/stream-tools/agent.go
+++ b/examples/stream-tools/agent.go
@@ -226,13 +226,22 @@ func main() {
 					}
 
 					for _, choice := range streamResponse.Choices {
-						// Handle reasoning
-						if choice.Delta.Reasoning != nil && *choice.Delta.Reasoning != "" {
+						// Handle reasoning (both reasoning and reasoning_content fields)
+						hasReasoning := (choice.Delta.Reasoning != nil && *choice.Delta.Reasoning != "") ||
+							(choice.Delta.ReasoningContent != nil && *choice.Delta.ReasoningContent != "")
+
+						if hasReasoning {
 							if !isThinking {
 								isThinking = true
 								fmt.Printf("\n💭 Thinking...\n")
 							}
-							fmt.Printf("\033[90m%s\033[0m", *choice.Delta.Reasoning)
+							// Handle both reasoning and reasoning_content fields
+							if choice.Delta.Reasoning != nil && *choice.Delta.Reasoning != "" {
+								fmt.Printf("\033[90m%s\033[0m", *choice.Delta.Reasoning)
+							}
+							if choice.Delta.ReasoningContent != nil && *choice.Delta.ReasoningContent != "" {
+								fmt.Printf("\033[90m%s\033[0m", *choice.Delta.ReasoningContent)
+							}
 						}
 
 						// Handle content

--- a/examples/stream/main.go
+++ b/examples/stream/main.go
@@ -82,7 +82,11 @@ func main() {
 					}
 
 					for _, choice := range streamResponse.Choices {
-						if choice.Delta.Reasoning != nil {
+						// Handle reasoning (both reasoning and reasoning_content fields)
+						hasReasoning := (choice.Delta.Reasoning != nil && *choice.Delta.Reasoning != "") ||
+							(choice.Delta.ReasoningContent != nil && *choice.Delta.ReasoningContent != "")
+
+						if hasReasoning {
 							if !isThinking {
 								// Start thinking animation if we weren't already thinking
 								isThinking = true
@@ -91,9 +95,14 @@ func main() {
 							}
 
 							// Store and display the reasoning content with special formatting
+							// Handle both reasoning and reasoning_content fields
 							if choice.Delta.Reasoning != nil && *choice.Delta.Reasoning != "" {
 								reasoningText += *choice.Delta.Reasoning
 								fmt.Printf("\033[90m%s\033[0m", *choice.Delta.Reasoning)
+							}
+							if choice.Delta.ReasoningContent != nil && *choice.Delta.ReasoningContent != "" {
+								reasoningText += *choice.Delta.ReasoningContent
+								fmt.Printf("\033[90m%s\033[0m", *choice.Delta.ReasoningContent)
 							}
 
 						} else if choice.Delta.Content != "" {


### PR DESCRIPTION
Fixes #17

This PR addresses the issue where `reasoning_content` from API responses was not being processed in streaming mode despite `ReasoningFormat` being set.

### Changes
- Updated `examples/stream/main.go` to handle both Reasoning and ReasoningContent fields
- Updated `examples/stream-tools/agent.go` to handle both Reasoning and ReasoningContent fields
- Updated README.md streaming example to demonstrate both fields
- Maintains backward compatibility with existing Reasoning field handling

### Testing
- All existing tests pass
- Linting passes
- Examples build successfully

Generated with [Claude Code](https://claude.ai/code)