### PR TITLE
feat(retry): Add retry logic with exponential backoff for HTTP requests

### DIFF
--- a/types.go
+++ b/types.go
@@ -60,6 +60,22 @@ type ClientOptions struct {
 	Tools *[]ChatCompletionTool
 	// Headers is a map of custom headers to include with all requests.
 	Headers map[string]string
+	// RetryConfig is the retry configuration for HTTP requests.
+	RetryConfig *RetryConfig
+}
+
+// RetryConfig represents the retry configuration for HTTP requests
+type RetryConfig struct {
+	// Enabled controls whether retry logic is enabled
+	Enabled bool
+	// MaxAttempts is the maximum number of retry attempts (including initial request)
+	MaxAttempts int
+	// InitialBackoffSec is the initial backoff delay in seconds
+	InitialBackoffSec int
+	// MaxBackoffSec is the maximum backoff delay in seconds
+	MaxBackoffSec int
+	// BackoffMultiplier is the multiplier for exponential backoff
+	BackoffMultiplier int
 }
 
 // MiddlewareOptions represents options for controlling middleware behavior


### PR DESCRIPTION
Implements retry logic with exponential backoff for HTTP requests as specified in issue #19.

## Changes
- Added `RetryConfig` type with configurable parameters
- Updated `ClientOptions` to include retry configuration
- Implemented exponential backoff with retry logic for all HTTP methods
- Added comprehensive test coverage
- Retry on transient errors (408, 429, 5xx) and network failures
- Context cancellation support during retries

Closes #19

Generated with [Claude Code](https://claude.ai/code)